### PR TITLE
add option to purge by url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Command to use for purge :
 Type of purge :
 - cpcode : Purge by cpcode
 - tag : Purge by Cache Tag
+- url : Purge by URL
 
 ### `ref`
 **Required** 
-CPCode or Cache Tag to purge
+CPCode, URL, or Cache Tag to purge
 
 
 ## Example usage

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,9 @@ inputs:
     description: 'Purge command (delete, invalidate)'
     required: true
   type:
-    description: 'Purge type (tags, cpcode, urls)'
+    description: 'Purge type (tag, cpcode, url)'
     required: true
-    default: 'tags'
+    default: 'tag'
   ref:
     description: 'Reference'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Purge command (delete, invalidate)'
     required: true
   type:
-    description: 'Purge type (tags, cpcode)'
+    description: 'Purge type (tags, cpcode, urls)'
     required: true
     default: 'tags'
   ref:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,10 @@ case ${_PURGE_TYPE} in
     _CLI_OPT="--tag"
   ;;
 
+  url)
+    _CLI_OPT=""
+  ;;
+
   *)
     echo "Unknown type '${_PURGE_TYPE}' ... exiting"
     exit 123


### PR DESCRIPTION
According to the [cli-purge docs](https://github.com/akamai/cli-purge/tree/1.0.1#usage), purging by URL is also possible.
This PR adds the option to use the `url` purge type to enable this.

I have also updated the docs so that the options in the input description actually match the ones that the action expects